### PR TITLE
feat: use configurable neon image from cluster spec

### DIFF
--- a/crates/neon_cluster/src/controllers/pageserver/pod.rs
+++ b/crates/neon_cluster/src/controllers/pageserver/pod.rs
@@ -343,7 +343,7 @@ fn create_pageserver_pod_spec(
             }]),
             containers: vec![Container {
                 name: "pageserver".to_string(),
-                image: Some("neondatabase/neon:7894".to_string()),
+                image: Some(neon_cluster.spec.neon_image.clone()),
                 image_pull_policy: Some("Always".to_string()),
                 command: Some(vec!["/usr/local/bin/pageserver".to_string()]),
                 ports: Some(vec![

--- a/crates/neon_cluster/src/controllers/safekeeper.rs
+++ b/crates/neon_cluster/src/controllers/safekeeper.rs
@@ -234,7 +234,7 @@ fn create_desired_statefulset(
                     }),
                     containers: vec![Container {
                         name: "safekeeper".to_string(),
-                        image: Some("neondatabase/neon:7894".to_string()),
+                        image: Some(neon_cluster.spec.neon_image.clone()),
                         command: Some(vec!["/bin/bash".to_string()]),
                         args: Some(vec!["-c".to_string(), safekeeper_command]),
                         ports: Some(vec![

--- a/crates/neon_cluster/src/controllers/storage_controller.rs
+++ b/crates/neon_cluster/src/controllers/storage_controller.rs
@@ -158,7 +158,7 @@ fn desired_deployment_spec(
                 spec: Some(PodSpec {
                     containers: vec![Container {
                         name: "neon-storage".to_string(),
-                        image: Some("neondatabase/neon:7894".to_string()),
+                        image: Some(cluster.spec.neon_image.clone()),
                         command: Some(vec!["storage_controller".to_string()]),
                         args: Some(
                             vec![


### PR DESCRIPTION
Use neon_image from NeonCluster spec for all components

Currently, neon_image is defined in the NeonCluster spec but not being used.
This change updates pageserver, safekeeper, storage_broker, and storage_controller to use the neon_image specified in the NeonCluster spec instead of hardcoded values.