### PR TITLE
refactor: inject storage_controller base url into reconcilers

### DIFF
--- a/internal/controller/branch_controller.go
+++ b/internal/controller/branch_controller.go
@@ -41,7 +41,8 @@ import (
 // BranchReconciler reconciles a Branch object
 type BranchReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme                   *runtime.Scheme
+	StorageControllerBaseURL string
 }
 
 // +kubebuilder:rbac:groups=neon.oltp.molnett.org,resources=branches,verbs=get;list;watch;create;update;patch;delete
@@ -198,13 +199,13 @@ func (r *BranchReconciler) getCluster(ctx context.Context, clusterName, namespac
 func (r *BranchReconciler) ensureTimeline(ctx context.Context, branch *neonv1alpha1.Branch, project *neonv1alpha1.Project) error {
 	log := logf.FromContext(ctx)
 
-	pageserverURL := fmt.Sprintf(
-		"http://%s-storage-controller:8080/v1/tenant/%s/timeline",
-		project.Spec.ClusterName,
-		project.Spec.TenantID,
-	)
+	base := r.StorageControllerBaseURL
+	if base == "" {
+		base = fmt.Sprintf("http://%s-storage-controller:8080", project.Spec.ClusterName)
+	}
+	storageControllerURL := fmt.Sprintf("%s/v1/tenant/%s/timeline", base, project.Spec.TenantID)
 
-	log.Info("Sending request to pageserver", "url", pageserverURL)
+	log.Info("Sending request to storage controller", "url", storageControllerURL)
 
 	requestBody := map[string]interface{}{
 		"new_timeline_id": branch.Spec.TimelineID,
@@ -220,10 +221,10 @@ func (r *BranchReconciler) ensureTimeline(ctx context.Context, branch *neonv1alp
 		Timeout: 10 * time.Second,
 	}
 
-	resp, err := httpClient.Post(pageserverURL, "application/json", bytes.NewBuffer(bodyBytes))
+	resp, err := httpClient.Post(storageControllerURL, "application/json", bytes.NewBuffer(bodyBytes))
 	if err != nil {
-		log.Info("Failed to connect to pageserver, will retry", "url", pageserverURL, "error", err)
-		return fmt.Errorf("failed to connect to pageserver: %w", err)
+		log.Info("Failed to connect to storage controller, will retry", "url", storageControllerURL, "error", err)
+		return fmt.Errorf("failed to connect to storage controller: %w", err)
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
@@ -232,11 +233,11 @@ func (r *BranchReconciler) ensureTimeline(ctx context.Context, branch *neonv1alp
 	}()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusConflict {
-		log.Info("Failed to create timeline on pageserver", "status", resp.StatusCode)
-		return fmt.Errorf("failed to create timeline on pageserver, status: %d", resp.StatusCode)
+		log.Info("Failed to create timeline on storage controller", "status", resp.StatusCode)
+		return fmt.Errorf("failed to create timeline on storage controller, status: %d", resp.StatusCode)
 	}
 
-	log.Info("Successfully created timeline on pageserver")
+	log.Info("Successfully created timeline on storage controller")
 	return nil
 }
 

--- a/internal/controller/project_controller.go
+++ b/internal/controller/project_controller.go
@@ -38,7 +38,8 @@ import (
 // ProjectReconciler reconciles a Project object
 type ProjectReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme                   *runtime.Scheme
+	StorageControllerBaseURL string
 }
 
 // +kubebuilder:rbac:groups=neon.oltp.molnett.org,resources=projects,verbs=get;list;watch;create;update;patch;delete
@@ -155,13 +156,13 @@ func (r *ProjectReconciler) updateTenantID(ctx context.Context, project *neonv1a
 func (r *ProjectReconciler) ensureTenantOnPageserver(ctx context.Context, project *neonv1alpha1.Project) error {
 	log := logf.FromContext(ctx)
 
-	storageControllerURL := fmt.Sprintf(
-		"http://%s-storage-controller:8080/v1/tenant/%s/location_config",
-		project.Spec.ClusterName,
-		project.Spec.TenantID,
-	)
+	base := r.StorageControllerBaseURL
+	if base == "" {
+		base = fmt.Sprintf("http://%s-storage-controller:8080", project.Spec.ClusterName)
+	}
+	storageControllerURL := fmt.Sprintf("%s/v1/tenant/%s/location_config", base, project.Spec.TenantID)
 
-	log.Info("Sending request to pageserver", "url", storageControllerURL)
+	log.Info("Sending request to storage controller", "url", storageControllerURL)
 
 	requestBody := []byte(`{"mode": "AttachedSingle", "generation": 1, "tenant_conf": {}}`)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, storageControllerURL, bytes.NewBuffer(requestBody))
@@ -173,7 +174,7 @@ func (r *ProjectReconciler) ensureTenantOnPageserver(ctx context.Context, projec
 	httpClient := &http.Client{Timeout: 30 * time.Second}
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		log.Info("Failed to connect to pageserver, will retry", "error", err, "url", storageControllerURL)
+		log.Info("Failed to connect to storage controller, will retry", "error", err, "url", storageControllerURL)
 		if setErr := utils.SetPhases(ctx, r.Client, project, func(p *neonv1alpha1.Project) {
 			utils.SetProjectPageserverConnectionErrorStatus(p, fmt.Sprintf("Failed to connect to pageserver: %v", err))
 		}); setErr != nil {
@@ -188,7 +189,7 @@ func (r *ProjectReconciler) ensureTenantOnPageserver(ctx context.Context, projec
 	}()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		log.Info("Pageserver returned error status", "status", resp.Status)
+		log.Info("Storage controller returned error status", "status", resp.Status)
 		if setErr := utils.SetPhases(ctx, r.Client, project, func(p *neonv1alpha1.Project) {
 			utils.SetProjectTenantCreationFailedStatus(p, fmt.Sprintf("Pageserver returned status: %s", resp.Status))
 		}); setErr != nil {
@@ -197,7 +198,7 @@ func (r *ProjectReconciler) ensureTenantOnPageserver(ctx context.Context, projec
 		return fmt.Errorf("pageserver returned status: %s", resp.Status)
 	}
 
-	log.Info("Successfully created tenant on pageserver")
+	log.Info("Successfully created tenant on storage controller")
 	return nil
 }
 


### PR DESCRIPTION
Adds an optional StorageControllerBaseURL field on each reconciler so tests can point at an httptest fake. Empty (the default) preserves the existing in-cluster DNS derivation, so production behavior is unchanged.

Also renames the local pageserverURL variable in branch_controller to storageControllerURL and updates the surrounding log strings — the operator talks to the storage_controller, not the pageserver, so the old wording was misleading anyone debugging from logs.