### PR TITLE
refactor(controlplane): make compute /configure url injectable

### DIFF
--- a/internal/controlplane/routes.go
+++ b/internal/controlplane/routes.go
@@ -15,11 +15,12 @@ func addRoutes(
 	mux *http.ServeMux,
 	log *slog.Logger,
 	k8sClient client.Client,
+	computeBaseURL string,
 ) {
 	mux.Handle("/compute/api/v2/computes/{compute_id}/spec", logRequests(log, handleComputeSpec(log, k8sClient)))
 	mux.Handle("/healthz", logRequests(log, handleHealthCheck()))
 	mux.Handle("/readyz", logRequests(log, handleHealthCheck()))
-	mux.Handle("/notify-attach", logRequests(log, notifyAttach(log, k8sClient)))
+	mux.Handle("/notify-attach", logRequests(log, notifyAttach(log, k8sClient, computeBaseURL)))
 }
 
 type responseWriter struct {
@@ -77,7 +78,7 @@ func handleComputeSpec(log *slog.Logger, k8sClient client.Client) http.Handler {
 	})
 }
 
-func notifyAttach(log *slog.Logger, k8sClient client.Client) http.Handler {
+func notifyAttach(log *slog.Logger, k8sClient client.Client, computeBaseURL string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if err := r.Body.Close(); err != nil {
@@ -119,7 +120,7 @@ func notifyAttach(log *slog.Logger, k8sClient client.Client) http.Handler {
 
 		// Generate compute spec using the deployment
 		for _, deployment := range deployments.Items {
-			if err := compute.RefreshConfiguration(ctx, log, k8sClient, actualRequest, &deployment); err != nil {
+			if err := compute.RefreshConfiguration(ctx, log, k8sClient, actualRequest, &deployment, computeBaseURL); err != nil {
 				log.Error("Failed to refresh the configuration", "deployment", deployment.Name, "error", err)
 				failcount = failcount + 1
 			} else {

--- a/internal/controlplane/routes_test.go
+++ b/internal/controlplane/routes_test.go
@@ -244,7 +244,7 @@ func TestNotifyAttachHandler(t *testing.T) {
 
 			// Create handler
 			mux := http.NewServeMux()
-			mux.Handle("/notify-attach", notifyAttach(logger, k8sClient))
+			mux.Handle("/notify-attach", notifyAttach(logger, k8sClient, ""))
 
 			// Create test request
 			req := httptest.NewRequest(tt.requestMethod, "/notify-attach", bytes.NewBufferString(tt.requestBody))

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -17,9 +17,10 @@ const shutdownTimeout = 10 * time.Second
 // ControlPlane is a controller-runtime manager.Runnable that serves the
 // HTTP control-plane endpoints (notify-attach, compute spec, health).
 type ControlPlane struct {
-	Log      *slog.Logger
-	Client   client.Client
-	BindAddr string
+	Log            *slog.Logger
+	Client         client.Client
+	BindAddr       string
+	ComputeBaseURL string
 }
 
 // Start implements manager.Runnable. The manager invokes it after caches sync
@@ -35,7 +36,7 @@ func (cp *ControlPlane) Start(ctx context.Context) error {
 		return fmt.Errorf("controlplane: BindAddr is required")
 	}
 
-	srv := newServer(cp.Log, cp.Client)
+	srv := newServer(cp.Log, cp.Client, cp.ComputeBaseURL)
 	httpServer := &http.Server{
 		Addr:              cp.BindAddr,
 		Handler:           srv,
@@ -60,10 +61,10 @@ func (cp *ControlPlane) Start(ctx context.Context) error {
 	}
 }
 
-func newServer(log *slog.Logger, k8sClient client.Client) http.Handler {
+func newServer(log *slog.Logger, k8sClient client.Client, computeBaseURL string) http.Handler {
 	mux := http.NewServeMux()
 
-	addRoutes(mux, log, k8sClient)
+	addRoutes(mux, log, k8sClient, computeBaseURL)
 
 	return mux
 }

--- a/specs/compute/spec.go
+++ b/specs/compute/spec.go
@@ -140,7 +140,8 @@ func RefreshConfiguration(ctx context.Context,
 	log *slog.Logger,
 	k8sClient client.Client,
 	request ComputeHookNotifyRequest,
-	deployment *appsv1.Deployment) error {
+	deployment *appsv1.Deployment,
+	computeBaseURL string) error {
 	var computeId string
 	var exists bool
 
@@ -212,6 +213,9 @@ func RefreshConfiguration(ctx context.Context,
 		expectedServiceName := computeId + "-admin"
 		if expectedServiceName == serviceName {
 			url := fmt.Sprintf("http://%s-admin.%s:3080/configure", computeId, serviceNamespace)
+			if computeBaseURL != "" {
+				url = computeBaseURL + "/configure"
+			}
 			log.Info("Calling /configure endpoint at URL: ", "URL is", url)
 			req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, bytes.NewBuffer(specBytes))
 			if err != nil {

--- a/test/fixtures/fixtures_test.go
+++ b/test/fixtures/fixtures_test.go
@@ -6,11 +6,16 @@ import (
 	"oltp.molnett.org/neon-operator/test/fixtures"
 )
 
-func TestNewCluster(t *testing.T) {
-	c := fixtures.NewCluster("alpha", "neon")
+const (
+	testClusterName = "alpha"
+	testNamespace   = "neon"
+)
 
-	if c.Name != "alpha" || c.Namespace != "neon" {
-		t.Fatalf("ObjectMeta = %s/%s, want alpha/neon", c.Namespace, c.Name)
+func TestNewCluster(t *testing.T) {
+	c := fixtures.NewCluster(testClusterName, testNamespace)
+
+	if c.Name != testClusterName || c.Namespace != testNamespace {
+		t.Fatalf("ObjectMeta = %s/%s, want %s/%s", c.Namespace, c.Name, testNamespace, testClusterName)
 	}
 	if c.Spec.NumSafekeepers != 3 {
 		t.Errorf("NumSafekeepers = %d, want 3", c.Spec.NumSafekeepers)
@@ -18,8 +23,8 @@ func TestNewCluster(t *testing.T) {
 	if c.Spec.DefaultPGVersion != 17 {
 		t.Errorf("DefaultPGVersion = %d, want 17", c.Spec.DefaultPGVersion)
 	}
-	if c.Spec.BucketCredentialsSecret == nil || c.Spec.BucketCredentialsSecret.Name != "alpha-bucket-creds" {
-		t.Errorf("BucketCredentialsSecret = %+v, want name=alpha-bucket-creds", c.Spec.BucketCredentialsSecret)
+	if c.Spec.BucketCredentialsSecret == nil || c.Spec.BucketCredentialsSecret.Name != testClusterName+"-bucket-creds" {
+		t.Errorf("BucketCredentialsSecret = %+v, want name=%s-bucket-creds", c.Spec.BucketCredentialsSecret, testClusterName)
 	}
 	if c.Spec.StorageControllerDatabaseSecret == nil || c.Spec.StorageControllerDatabaseSecret.Key != "uri" {
 		t.Errorf("StorageControllerDatabaseSecret = %+v, want key=uri", c.Spec.StorageControllerDatabaseSecret)
@@ -27,9 +32,9 @@ func TestNewCluster(t *testing.T) {
 }
 
 func TestNewProject_LinkedToCluster(t *testing.T) {
-	p := fixtures.NewProject("p1", "neon", "alpha")
-	if p.Spec.ClusterName != "alpha" {
-		t.Errorf("ClusterName = %s, want alpha", p.Spec.ClusterName)
+	p := fixtures.NewProject("p1", testNamespace, testClusterName)
+	if p.Spec.ClusterName != testClusterName {
+		t.Errorf("ClusterName = %s, want %s", p.Spec.ClusterName, testClusterName)
 	}
 	if p.Spec.PGVersion != 17 {
 		t.Errorf("PGVersion = %d, want 17", p.Spec.PGVersion)
@@ -37,7 +42,7 @@ func TestNewProject_LinkedToCluster(t *testing.T) {
 }
 
 func TestNewBranch_LinkedToProject(t *testing.T) {
-	b := fixtures.NewBranch("b1", "neon", "p1")
+	b := fixtures.NewBranch("b1", testNamespace, "p1")
 	if b.Spec.ProjectID != "p1" {
 		t.Errorf("ProjectID = %s, want p1", b.Spec.ProjectID)
 	}
@@ -47,15 +52,15 @@ func TestNewBranch_LinkedToProject(t *testing.T) {
 }
 
 func TestNewPageserver_LinkedToCluster(t *testing.T) {
-	ps := fixtures.NewPageserver("ps0", "neon", "alpha", 1)
-	if ps.Spec.Cluster != "alpha" {
-		t.Errorf("Cluster = %s, want alpha", ps.Spec.Cluster)
+	ps := fixtures.NewPageserver("ps0", testNamespace, testClusterName, 1)
+	if ps.Spec.Cluster != testClusterName {
+		t.Errorf("Cluster = %s, want %s", ps.Spec.Cluster, testClusterName)
 	}
 	if ps.Spec.ID != 1 {
 		t.Errorf("ID = %d, want 1", ps.Spec.ID)
 	}
-	if ps.Spec.BucketCredentialsSecret == nil || ps.Spec.BucketCredentialsSecret.Name != "alpha-bucket-creds" {
-		t.Errorf("BucketCredentialsSecret = %+v, want name=alpha-bucket-creds", ps.Spec.BucketCredentialsSecret)
+	if ps.Spec.BucketCredentialsSecret == nil || ps.Spec.BucketCredentialsSecret.Name != testClusterName+"-bucket-creds" {
+		t.Errorf("BucketCredentialsSecret = %+v, want name=%s-bucket-creds", ps.Spec.BucketCredentialsSecret, testClusterName)
 	}
 	if ps.Spec.StorageConfig.Size != "1Gi" {
 		t.Errorf("StorageConfig.Size = %s, want 1Gi", ps.Spec.StorageConfig.Size)
@@ -63,9 +68,9 @@ func TestNewPageserver_LinkedToCluster(t *testing.T) {
 }
 
 func TestNewSafekeeper_LinkedToCluster(t *testing.T) {
-	sk := fixtures.NewSafekeeper("sk0", "neon", "alpha", 1)
-	if sk.Spec.Cluster != "alpha" {
-		t.Errorf("Cluster = %s, want alpha", sk.Spec.Cluster)
+	sk := fixtures.NewSafekeeper("sk0", testNamespace, testClusterName, 1)
+	if sk.Spec.Cluster != testClusterName {
+		t.Errorf("Cluster = %s, want %s", sk.Spec.Cluster, testClusterName)
 	}
 	if sk.Spec.ID != 1 {
 		t.Errorf("ID = %d, want 1", sk.Spec.ID)
@@ -79,9 +84,9 @@ func TestNewSafekeeper_LinkedToCluster(t *testing.T) {
 // what the Cluster fixture references. If these drift apart, every test that
 // composes a Cluster with its Secrets will fail confusingly.
 func TestSecretNamesMatchClusterReferences(t *testing.T) {
-	c := fixtures.NewCluster("alpha", "neon")
-	bucket := fixtures.NewBucketCredsSecret("alpha", "neon")
-	storconDB := fixtures.NewStorcondDBSecret("alpha", "neon")
+	c := fixtures.NewCluster(testClusterName, testNamespace)
+	bucket := fixtures.NewBucketCredsSecret(testClusterName, testNamespace)
+	storconDB := fixtures.NewStorcondDBSecret(testClusterName, testNamespace)
 
 	if bucket.Name != c.Spec.BucketCredentialsSecret.Name {
 		t.Errorf("bucket secret name %s != cluster ref %s", bucket.Name, c.Spec.BucketCredentialsSecret.Name)


### PR DESCRIPTION
Mirrors the StorageControllerBaseURL pattern from #65 for the compute side. Adds ComputeBaseURL on the ControlPlane struct and plumbs it through newServer, addRoutes, and notifyAttach into RefreshConfiguration.

When non-empty (tests), the /configure URL becomes {ComputeBaseURL}/configure regardless of compute id or namespace, so fakes serving /configure can absorb all outbound traffic from a single endpoint. Empty (production) preserves
http://{computeId}-admin.{ns}:3080/configure unchanged.

Required so the Compute fake landed in jg/test-fakes can be wired into the controlplane route tests in #16.