### PR TITLE
feat(api): enforce CRD safety validation

### DIFF
--- a/api/v1alpha1/branch_types.go
+++ b/api/v1alpha1/branch_types.go
@@ -21,18 +21,22 @@ import (
 )
 
 // BranchSpec defines the desired state of Branch
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.timelineID) || oldSelf.timelineID.size() == 0 || (has(self.timelineID) && self.timelineID == oldSelf.timelineID)",message="timelineID can be generated once, but cannot be changed after it is set"
+// +kubebuilder:validation:XValidation:rule="self.projectID == oldSelf.projectID",message="projectID is immutable"
 type BranchSpec struct {
 	// Will be generated unless specified.
 	// Has to be a 32 character alphanumeric string.
 	// +optional
+	// +kubebuilder:validation:Pattern:=`^$|^[0-9a-f]{32}$`
 	TimelineID string `json:"timelineID"`
 
 	// PGVersion specifies the PostgreSQL version to use for the branch.
-	// kubebuilder:validation:Enum=14;15;16;17
-	// kubebuilder:default:=17
+	// +kubebuilder:validation:Enum=14;15;16;17
+	// +kubebuilder:default:=17
 	PGVersion int `json:"pgVersion"`
 
 	// The ID of the Project this Branch belongs to
+	// +kubebuilder:validation:MinLength:=1
 	ProjectID string `json:"projectID"`
 }
 

--- a/api/v1alpha1/cluster_types.go
+++ b/api/v1alpha1/cluster_types.go
@@ -22,18 +22,24 @@ import (
 )
 
 // ClusterSpec defines the desired state of Cluster
+// +kubebuilder:validation:XValidation:rule="has(self.bucketCredentialsSecret.name) && self.bucketCredentialsSecret.name.size() > 0",message="bucketCredentialsSecret.name is required"
+// +kubebuilder:validation:XValidation:rule="self.storageControllerDatabaseSecret.name.size() > 0",message="storageControllerDatabaseSecret.name is required"
+// +kubebuilder:validation:XValidation:rule="self.storageControllerDatabaseSecret.key.size() > 0",message="storageControllerDatabaseSecret.key is required"
 type ClusterSpec struct {
 	// Decides how many safekeepers to run in the cluster.
 	// +kubebuilder:default:=3
 	// +kubebuilder:validation:Minimum:=3
+	// +kubebuilder:validation:Maximum:=3
 	NumSafekeepers uint8 `json:"numSafekeepers"`
 
 	// Default PostgreSQL version to use if no version is specified in projects.
-	// kubebuilder:validation:Enum=14;15;16;17
+	// +kubebuilder:validation:Enum=14;15;16;17
+	// +kubebuilder:default:=17
 	DefaultPGVersion int `json:"defaultPGVersion"`
 
 	// The default Neon image to use for all neon-specific resources.
 	// +kubebuilder:default:="neondatabase/neon:8463"
+	// +kubebuilder:validation:MinLength:=1
 	NeonImage string `json:"neonImage"`
 
 	// Reference to a Secret containing credentials for accessing a storage bucket.

--- a/api/v1alpha1/pageserver_types.go
+++ b/api/v1alpha1/pageserver_types.go
@@ -22,12 +22,18 @@ import (
 )
 
 // PageserverSpec defines the desired state of Pageserver
+// +kubebuilder:validation:XValidation:rule="self.id == oldSelf.id",message="id is immutable"
+// +kubebuilder:validation:XValidation:rule="self.cluster == oldSelf.cluster",message="cluster is immutable"
+// +kubebuilder:validation:XValidation:rule="self.storageConfig.size == oldSelf.storageConfig.size",message="storageConfig.size is immutable"
+// +kubebuilder:validation:XValidation:rule="has(self.storageConfig.storageClass) == has(oldSelf.storageConfig.storageClass) && (!has(self.storageConfig.storageClass) || self.storageConfig.storageClass == oldSelf.storageConfig.storageClass)",message="storageConfig.storageClass is immutable"
+// +kubebuilder:validation:XValidation:rule="has(self.bucketCredentialsSecret.name) && self.bucketCredentialsSecret.name.size() > 0",message="bucketCredentialsSecret.name is required"
 type PageserverSpec struct {
 	// ID which the pageserver uses when registering with storage-controller
 	// This ID must be unique within the cluster.
 	ID uint64 `json:"id"`
 
 	// Used to deterministically setup which storage controller and broker to communicate with
+	// +kubebuilder:validation:MinLength:=1
 	Cluster string `json:"cluster"`
 
 	// Reference to a Secret containing credentials for accessing a storage bucket.

--- a/api/v1alpha1/project_types.go
+++ b/api/v1alpha1/project_types.go
@@ -21,17 +21,23 @@ import (
 )
 
 // ProjectSpec defines the desired state of Project
+// +kubebuilder:validation:XValidation:rule="self.cluster == oldSelf.cluster",message="cluster is immutable"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.tenantId) || oldSelf.tenantId.size() == 0 || (has(self.tenantId) && self.tenantId == oldSelf.tenantId)",message="tenantId can be generated once, but cannot be changed after it is set"
 type ProjectSpec struct {
 	// Name of the cluster where the project will be created.
+	// +kubebuilder:validation:MinLength:=1
 	ClusterName string `json:"cluster"`
 
 	// Will be generated unless specified.
 	// Has to be a 32 character alphanumeric string.
 	// +optional
+	// +kubebuilder:validation:Pattern:=`^$|^[0-9a-f]{32}$`
 	TenantID string `json:"tenantId"`
 
 	// PostgreSQL version to use for the project.
 	// +optional
+	// +kubebuilder:validation:Enum=14;15;16;17
+	// +kubebuilder:default:=17
 	PGVersion int `json:"pgVersion"`
 }
 

--- a/api/v1alpha1/safekeeper_types.go
+++ b/api/v1alpha1/safekeeper_types.go
@@ -26,17 +26,23 @@ type StorageConfig struct {
 	StorageClass *string `json:"storageClass,omitempty"`
 
 	// Size of the PVCs.
-	// kubebuilder:default:=10Gi
+	// +kubebuilder:default:="10Gi"
+	// +kubebuilder:validation:Pattern:=`^[0-9]+(Ei|Pi|Ti|Gi|Mi|Ki|E|P|T|G|M|K|m)?$`
 	Size string `json:"size"`
 }
 
 // SafekeeperSpec defines the desired state of Safekeeper
+// +kubebuilder:validation:XValidation:rule="self.id == oldSelf.id",message="id is immutable"
+// +kubebuilder:validation:XValidation:rule="self.cluster == oldSelf.cluster",message="cluster is immutable"
+// +kubebuilder:validation:XValidation:rule="self.storageConfig.size == oldSelf.storageConfig.size",message="storageConfig.size is immutable"
+// +kubebuilder:validation:XValidation:rule="has(self.storageConfig.storageClass) == has(oldSelf.storageConfig.storageClass) && (!has(self.storageConfig.storageClass) || self.storageConfig.storageClass == oldSelf.storageConfig.storageClass)",message="storageConfig.storageClass is immutable"
 type SafekeeperSpec struct {
 	// ID which the safekeepers uses when registering with storage-controller
 	// This ID must be unique within the cluster.
 	ID uint32 `json:"id"`
 
 	// Used to deterministically setup which storage controller and broker to communicate with
+	// +kubebuilder:validation:MinLength:=1
 	Cluster string `json:"cluster"`
 
 	// PVC configuration

--- a/config/crd/bases/neon.oltp.molnett.org_branches.yaml
+++ b/config/crd/bases/neon.oltp.molnett.org_branches.yaml
@@ -50,23 +50,36 @@ spec:
             description: spec defines the desired state of Branch
             properties:
               pgVersion:
-                description: |-
-                  PGVersion specifies the PostgreSQL version to use for the branch.
-                  kubebuilder:validation:Enum=14;15;16;17
-                  kubebuilder:default:=17
+                default: 17
+                description: PGVersion specifies the PostgreSQL version to use for
+                  the branch.
+                enum:
+                - 14
+                - 15
+                - 16
+                - 17
                 type: integer
               projectID:
                 description: The ID of the Project this Branch belongs to
+                minLength: 1
                 type: string
               timelineID:
                 description: |-
                   Will be generated unless specified.
                   Has to be a 32 character alphanumeric string.
+                pattern: ^$|^[0-9a-f]{32}$
                 type: string
             required:
             - pgVersion
             - projectID
             type: object
+            x-kubernetes-validations:
+            - message: timelineID can be generated once, but cannot be changed after
+                it is set
+              rule: '!has(oldSelf.timelineID) || oldSelf.timelineID.size() == 0 ||
+                (has(self.timelineID) && self.timelineID == oldSelf.timelineID)'
+            - message: projectID is immutable
+              rule: self.projectID == oldSelf.projectID
           status:
             description: status defines the observed state of Branch
             properties:

--- a/config/crd/bases/neon.oltp.molnett.org_clusters.yaml
+++ b/config/crd/bases/neon.oltp.molnett.org_clusters.yaml
@@ -64,17 +64,24 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               defaultPGVersion:
-                description: |-
-                  Default PostgreSQL version to use if no version is specified in projects.
-                  kubebuilder:validation:Enum=14;15;16;17
+                default: 17
+                description: Default PostgreSQL version to use if no version is specified
+                  in projects.
+                enum:
+                - 14
+                - 15
+                - 16
+                - 17
                 type: integer
               neonImage:
                 default: neondatabase/neon:8463
                 description: The default Neon image to use for all neon-specific resources.
+                minLength: 1
                 type: string
               numSafekeepers:
                 default: 3
                 description: Decides how many safekeepers to run in the cluster.
+                maximum: 3
                 minimum: 3
                 type: integer
               storageControllerDatabaseSecret:
@@ -109,6 +116,14 @@ spec:
             - numSafekeepers
             - storageControllerDatabaseSecret
             type: object
+            x-kubernetes-validations:
+            - message: bucketCredentialsSecret.name is required
+              rule: has(self.bucketCredentialsSecret.name) && self.bucketCredentialsSecret.name.size()
+                > 0
+            - message: storageControllerDatabaseSecret.name is required
+              rule: self.storageControllerDatabaseSecret.name.size() > 0
+            - message: storageControllerDatabaseSecret.key is required
+              rule: self.storageControllerDatabaseSecret.key.size() > 0
           status:
             description: |-
               status defines the observed state of Cluster

--- a/config/crd/bases/neon.oltp.molnett.org_pageservers.yaml
+++ b/config/crd/bases/neon.oltp.molnett.org_pageservers.yaml
@@ -66,6 +66,7 @@ spec:
               cluster:
                 description: Used to deterministically setup which storage controller
                   and broker to communicate with
+                minLength: 1
                 type: string
               id:
                 description: |-
@@ -77,9 +78,9 @@ spec:
                 description: PVC configuration
                 properties:
                   size:
-                    description: |-
-                      Size of the PVCs.
-                      kubebuilder:default:=10Gi
+                    default: 10Gi
+                    description: Size of the PVCs.
+                    pattern: ^[0-9]+(Ei|Pi|Ti|Gi|Mi|Ki|E|P|T|G|M|K|m)?$
                     type: string
                   storageClass:
                     description: Name of the storage class to use for PVCs.
@@ -93,6 +94,20 @@ spec:
             - id
             - storageConfig
             type: object
+            x-kubernetes-validations:
+            - message: id is immutable
+              rule: self.id == oldSelf.id
+            - message: cluster is immutable
+              rule: self.cluster == oldSelf.cluster
+            - message: storageConfig.size is immutable
+              rule: self.storageConfig.size == oldSelf.storageConfig.size
+            - message: storageConfig.storageClass is immutable
+              rule: has(self.storageConfig.storageClass) == has(oldSelf.storageConfig.storageClass)
+                && (!has(self.storageConfig.storageClass) || self.storageConfig.storageClass
+                == oldSelf.storageConfig.storageClass)
+            - message: bucketCredentialsSecret.name is required
+              rule: has(self.bucketCredentialsSecret.name) && self.bucketCredentialsSecret.name.size()
+                > 0
           status:
             description: status defines the observed state of Pageserver
             properties:

--- a/config/crd/bases/neon.oltp.molnett.org_projects.yaml
+++ b/config/crd/bases/neon.oltp.molnett.org_projects.yaml
@@ -51,18 +51,33 @@ spec:
             properties:
               cluster:
                 description: Name of the cluster where the project will be created.
+                minLength: 1
                 type: string
               pgVersion:
+                default: 17
                 description: PostgreSQL version to use for the project.
+                enum:
+                - 14
+                - 15
+                - 16
+                - 17
                 type: integer
               tenantId:
                 description: |-
                   Will be generated unless specified.
                   Has to be a 32 character alphanumeric string.
+                pattern: ^$|^[0-9a-f]{32}$
                 type: string
             required:
             - cluster
             type: object
+            x-kubernetes-validations:
+            - message: cluster is immutable
+              rule: self.cluster == oldSelf.cluster
+            - message: tenantId can be generated once, but cannot be changed after
+                it is set
+              rule: '!has(oldSelf.tenantId) || oldSelf.tenantId.size() == 0 || (has(self.tenantId)
+                && self.tenantId == oldSelf.tenantId)'
           status:
             description: status defines the observed state of Project
             properties:

--- a/config/crd/bases/neon.oltp.molnett.org_safekeepers.yaml
+++ b/config/crd/bases/neon.oltp.molnett.org_safekeepers.yaml
@@ -52,6 +52,7 @@ spec:
               cluster:
                 description: Used to deterministically setup which storage controller
                   and broker to communicate with
+                minLength: 1
                 type: string
               id:
                 description: |-
@@ -63,9 +64,9 @@ spec:
                 description: PVC configuration
                 properties:
                   size:
-                    description: |-
-                      Size of the PVCs.
-                      kubebuilder:default:=10Gi
+                    default: 10Gi
+                    description: Size of the PVCs.
+                    pattern: ^[0-9]+(Ei|Pi|Ti|Gi|Mi|Ki|E|P|T|G|M|K|m)?$
                     type: string
                   storageClass:
                     description: Name of the storage class to use for PVCs.
@@ -78,6 +79,17 @@ spec:
             - id
             - storageConfig
             type: object
+            x-kubernetes-validations:
+            - message: id is immutable
+              rule: self.id == oldSelf.id
+            - message: cluster is immutable
+              rule: self.cluster == oldSelf.cluster
+            - message: storageConfig.size is immutable
+              rule: self.storageConfig.size == oldSelf.storageConfig.size
+            - message: storageConfig.storageClass is immutable
+              rule: has(self.storageConfig.storageClass) == has(oldSelf.storageConfig.storageClass)
+                && (!has(self.storageConfig.storageClass) || self.storageConfig.storageClass
+                == oldSelf.storageConfig.storageClass)
           status:
             description: status defines the observed state of Safekeeper
             properties:

--- a/internal/controller/api_validation_test.go
+++ b/internal/controller/api_validation_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	neonv1alpha1 "oltp.molnett.org/neon-operator/api/v1alpha1"
+	"oltp.molnett.org/neon-operator/test/fixtures"
+)
+
+var _ = Describe("API validation", func() {
+	var namespace string
+
+	BeforeEach(func() {
+		namespace = newTestNamespace()
+	})
+
+	It("rejects unsupported cluster topology", func() {
+		cluster := fixtures.NewCluster("invalid-topology", namespace)
+		cluster.Spec.NumSafekeepers = 4
+
+		err := k8sClient.Create(ctx, cluster)
+		Expect(apierrors.IsInvalid(err)).To(BeTrue(), "expected invalid error, got %v", err)
+	})
+
+	It("rejects malformed generated IDs", func() {
+		project := fixtures.NewProject("bad-tenant", namespace, "cluster-a")
+		project.Spec.TenantID = "not-a-neon-id"
+		Expect(apierrors.IsInvalid(k8sClient.Create(ctx, project))).To(BeTrue())
+
+		branch := fixtures.NewBranch("bad-timeline", namespace, "project-a")
+		branch.Spec.TimelineID = "not-a-neon-id"
+		Expect(apierrors.IsInvalid(k8sClient.Create(ctx, branch))).To(BeTrue())
+	})
+
+	It("rejects invalid storage sizes before specs can panic while parsing them", func() {
+		sk := fixtures.NewSafekeeper("bad-storage", namespace, "cluster-a", 0)
+		sk.Spec.StorageConfig.Size = "tenGi"
+		Expect(apierrors.IsInvalid(k8sClient.Create(ctx, sk))).To(BeTrue())
+	})
+
+	It("prevents generated IDs from changing after they are set", func() {
+		project := fixtures.NewProject("immutable-tenant", namespace, "cluster-a")
+		project.Spec.TenantID = "00000000000000000000000000000001"
+		Expect(k8sClient.Create(ctx, project)).To(Succeed())
+
+		current := &neonv1alpha1.Project{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: project.Name, Namespace: namespace}, current)).To(Succeed())
+		current.Spec.TenantID = "00000000000000000000000000000002"
+
+		err := k8sClient.Update(ctx, current)
+		Expect(apierrors.IsInvalid(err)).To(BeTrue(), "expected invalid error, got %v", err)
+	})
+})

--- a/internal/controller/api_validation_test.go
+++ b/internal/controller/api_validation_test.go
@@ -22,6 +22,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 
 	neonv1alpha1 "oltp.molnett.org/neon-operator/api/v1alpha1"
 	"oltp.molnett.org/neon-operator/test/fixtures"
@@ -63,11 +64,21 @@ var _ = Describe("API validation", func() {
 		project.Spec.TenantID = "00000000000000000000000000000001"
 		Expect(k8sClient.Create(ctx, project)).To(Succeed())
 
-		current := &neonv1alpha1.Project{}
-		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: project.Name, Namespace: namespace}, current)).To(Succeed())
-		current.Spec.TenantID = "00000000000000000000000000000002"
-
-		err := k8sClient.Update(ctx, current)
-		Expect(apierrors.IsInvalid(err)).To(BeTrue(), "expected invalid error, got %v", err)
+		invalid := false
+		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			current := &neonv1alpha1.Project{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: project.Name, Namespace: namespace}, current); err != nil {
+				return err
+			}
+			current.Spec.TenantID = "00000000000000000000000000000002"
+			err := k8sClient.Update(ctx, current)
+			if apierrors.IsInvalid(err) {
+				invalid = true
+				return nil
+			}
+			return err
+		})
+		Expect(err).NotTo(HaveOccurred(), "expected invalid error, got %v", err)
+		Expect(invalid).To(BeTrue(), "expected invalid error")
 	})
 })

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -43,6 +43,8 @@ import (
 // namespace where the project is deployed in
 const namespace = "neon"
 
+const validationUpdatedClusterName = "cluster-b"
+
 // serviceAccountName created for the project
 const serviceAccountName = "neon-controller-manager"
 
@@ -285,6 +287,24 @@ var _ = Describe("Manager", Ordered, func() {
 		It("rejects unsupported values on create", func() {
 			ctx := context.Background()
 			cli := newE2EClient()
+			emptyClusterSecretName := func(c *neonv1alpha1.Cluster) {
+				c.Spec.BucketCredentialsSecret.Name = ""
+			}
+			emptyStorconSecretName := func(c *neonv1alpha1.Cluster) {
+				c.Spec.StorageControllerDatabaseSecret.Name = ""
+			}
+			emptyStorconSecretKey := func(c *neonv1alpha1.Cluster) {
+				c.Spec.StorageControllerDatabaseSecret.Key = ""
+			}
+			emptyPageserverSecretName := func(p *neonv1alpha1.Pageserver) {
+				p.Spec.BucketCredentialsSecret.Name = ""
+			}
+			badPageserverStorageSize := func(p *neonv1alpha1.Pageserver) {
+				p.Spec.StorageConfig.Size = "tenGi"
+			}
+			badSafekeeperStorageSize := func(s *neonv1alpha1.Safekeeper) {
+				s.Spec.StorageConfig.Size = "tenGi"
+			}
 			next := 0
 			name := func(prefix string) string {
 				next++
@@ -323,9 +343,9 @@ var _ = Describe("Manager", Ordered, func() {
 				{name: "Cluster numSafekeepers", obj: cluster(func(c *neonv1alpha1.Cluster) { c.Spec.NumSafekeepers = 4 })},
 				{name: "Cluster defaultPGVersion", obj: cluster(func(c *neonv1alpha1.Cluster) { c.Spec.DefaultPGVersion = 13 })},
 				{name: "Cluster neonImage", obj: cluster(func(c *neonv1alpha1.Cluster) { c.Spec.NeonImage = "" })},
-				{name: "Cluster bucketCredentialsSecret.name", obj: cluster(func(c *neonv1alpha1.Cluster) { c.Spec.BucketCredentialsSecret.Name = "" })},
-				{name: "Cluster storageControllerDatabaseSecret.name", obj: cluster(func(c *neonv1alpha1.Cluster) { c.Spec.StorageControllerDatabaseSecret.Name = "" })},
-				{name: "Cluster storageControllerDatabaseSecret.key", obj: cluster(func(c *neonv1alpha1.Cluster) { c.Spec.StorageControllerDatabaseSecret.Key = "" })},
+				{name: "Cluster bucketCredentialsSecret.name", obj: cluster(emptyClusterSecretName)},
+				{name: "Cluster storageControllerDatabaseSecret.name", obj: cluster(emptyStorconSecretName)},
+				{name: "Cluster storageControllerDatabaseSecret.key", obj: cluster(emptyStorconSecretKey)},
 				{name: "Project cluster", obj: project(func(p *neonv1alpha1.Project) { p.Spec.ClusterName = "" })},
 				{name: "Project tenantId", obj: project(func(p *neonv1alpha1.Project) { p.Spec.TenantID = "not-a-neon-id" })},
 				{name: "Project pgVersion", obj: project(func(p *neonv1alpha1.Project) { p.Spec.PGVersion = 13 })},
@@ -333,10 +353,10 @@ var _ = Describe("Manager", Ordered, func() {
 				{name: "Branch timelineID", obj: branch(func(b *neonv1alpha1.Branch) { b.Spec.TimelineID = "not-a-neon-id" })},
 				{name: "Branch pgVersion", obj: branch(func(b *neonv1alpha1.Branch) { b.Spec.PGVersion = 13 })},
 				{name: "Pageserver cluster", obj: pageserver(func(p *neonv1alpha1.Pageserver) { p.Spec.Cluster = "" })},
-				{name: "Pageserver bucketCredentialsSecret.name", obj: pageserver(func(p *neonv1alpha1.Pageserver) { p.Spec.BucketCredentialsSecret.Name = "" })},
-				{name: "Pageserver storageConfig.size", obj: pageserver(func(p *neonv1alpha1.Pageserver) { p.Spec.StorageConfig.Size = "tenGi" })},
+				{name: "Pageserver bucketCredentialsSecret.name", obj: pageserver(emptyPageserverSecretName)},
+				{name: "Pageserver storageConfig.size", obj: pageserver(badPageserverStorageSize)},
 				{name: "Safekeeper cluster", obj: safekeeper(func(s *neonv1alpha1.Safekeeper) { s.Spec.Cluster = "" })},
-				{name: "Safekeeper storageConfig.size", obj: safekeeper(func(s *neonv1alpha1.Safekeeper) { s.Spec.StorageConfig.Size = "tenGi" })},
+				{name: "Safekeeper storageConfig.size", obj: safekeeper(badSafekeeperStorageSize)},
 			} {
 				By("expecting invalid create for " + tc.name)
 				err := cli.Create(ctx, tc.obj)
@@ -406,36 +426,66 @@ var _ = Describe("Manager", Ordered, func() {
 			Expect(cli.Create(ctx, project)).To(Succeed())
 
 			projectKey := types.NamespacedName{Name: project.Name, Namespace: namespace}
-			expectInvalidUpdate("Project cluster immutability", updateProject(projectKey, func(p *neonv1alpha1.Project) { p.Spec.ClusterName = "cluster-b" }))
-			expectInvalidUpdate("Project tenantId immutability", updateProject(projectKey, func(p *neonv1alpha1.Project) { p.Spec.TenantID = "00000000000000000000000000000002" }))
+			expectInvalidUpdate("Project cluster immutability", updateProject(projectKey, func(p *neonv1alpha1.Project) {
+				p.Spec.ClusterName = validationUpdatedClusterName
+			}))
+			expectInvalidUpdate("Project tenantId immutability", updateProject(projectKey, func(p *neonv1alpha1.Project) {
+				p.Spec.TenantID = "00000000000000000000000000000002"
+			}))
 
 			branch := fixtures.NewBranch("validation-branch-update", namespace, "project-a")
 			branch.Spec.TimelineID = "00000000000000000000000000000001"
 			Expect(cli.Create(ctx, branch)).To(Succeed())
 
 			branchKey := types.NamespacedName{Name: branch.Name, Namespace: namespace}
-			expectInvalidUpdate("Branch projectID immutability", updateBranch(branchKey, func(b *neonv1alpha1.Branch) { b.Spec.ProjectID = "project-b" }))
-			expectInvalidUpdate("Branch timelineID immutability", updateBranch(branchKey, func(b *neonv1alpha1.Branch) { b.Spec.TimelineID = "00000000000000000000000000000002" }))
+			expectInvalidUpdate("Branch projectID immutability", updateBranch(branchKey, func(b *neonv1alpha1.Branch) {
+				b.Spec.ProjectID = "project-b"
+			}))
+			expectInvalidUpdate("Branch timelineID immutability", updateBranch(branchKey, func(b *neonv1alpha1.Branch) {
+				b.Spec.TimelineID = "00000000000000000000000000000002"
+			}))
 
 			pageserver := fixtures.NewPageserver("validation-pageserver-update", namespace, "cluster-a", 0)
 			pageserver.Spec.StorageConfig.StorageClass = ptr.To("fast")
 			Expect(cli.Create(ctx, pageserver)).To(Succeed())
 
 			pageserverKey := types.NamespacedName{Name: pageserver.Name, Namespace: namespace}
-			expectInvalidUpdate("Pageserver id immutability", updatePageserver(pageserverKey, func(p *neonv1alpha1.Pageserver) { p.Spec.ID = 1 }))
-			expectInvalidUpdate("Pageserver cluster immutability", updatePageserver(pageserverKey, func(p *neonv1alpha1.Pageserver) { p.Spec.Cluster = "cluster-b" }))
-			expectInvalidUpdate("Pageserver storage size immutability", updatePageserver(pageserverKey, func(p *neonv1alpha1.Pageserver) { p.Spec.StorageConfig.Size = "2Gi" }))
-			expectInvalidUpdate("Pageserver storage class immutability", updatePageserver(pageserverKey, func(p *neonv1alpha1.Pageserver) { p.Spec.StorageConfig.StorageClass = ptr.To("slow") }))
+			expectInvalidUpdate("Pageserver id immutability", updatePageserver(pageserverKey, func(p *neonv1alpha1.Pageserver) {
+				p.Spec.ID = 1
+			}))
+			expectInvalidUpdate("Pageserver cluster immutability", updatePageserver(
+				pageserverKey,
+				func(p *neonv1alpha1.Pageserver) { p.Spec.Cluster = validationUpdatedClusterName },
+			))
+			expectInvalidUpdate("Pageserver storage size immutability", updatePageserver(
+				pageserverKey,
+				func(p *neonv1alpha1.Pageserver) { p.Spec.StorageConfig.Size = "2Gi" },
+			))
+			expectInvalidUpdate("Pageserver storage class immutability", updatePageserver(
+				pageserverKey,
+				func(p *neonv1alpha1.Pageserver) { p.Spec.StorageConfig.StorageClass = ptr.To("slow") },
+			))
 
 			safekeeper := fixtures.NewSafekeeper("validation-safekeeper-update", namespace, "cluster-a", 0)
 			safekeeper.Spec.StorageConfig.StorageClass = ptr.To("fast")
 			Expect(cli.Create(ctx, safekeeper)).To(Succeed())
 
 			safekeeperKey := types.NamespacedName{Name: safekeeper.Name, Namespace: namespace}
-			expectInvalidUpdate("Safekeeper id immutability", updateSafekeeper(safekeeperKey, func(s *neonv1alpha1.Safekeeper) { s.Spec.ID = 1 }))
-			expectInvalidUpdate("Safekeeper cluster immutability", updateSafekeeper(safekeeperKey, func(s *neonv1alpha1.Safekeeper) { s.Spec.Cluster = "cluster-b" }))
-			expectInvalidUpdate("Safekeeper storage size immutability", updateSafekeeper(safekeeperKey, func(s *neonv1alpha1.Safekeeper) { s.Spec.StorageConfig.Size = "2Gi" }))
-			expectInvalidUpdate("Safekeeper storage class immutability", updateSafekeeper(safekeeperKey, func(s *neonv1alpha1.Safekeeper) { s.Spec.StorageConfig.StorageClass = ptr.To("slow") }))
+			expectInvalidUpdate("Safekeeper id immutability", updateSafekeeper(safekeeperKey, func(s *neonv1alpha1.Safekeeper) {
+				s.Spec.ID = 1
+			}))
+			expectInvalidUpdate("Safekeeper cluster immutability", updateSafekeeper(
+				safekeeperKey,
+				func(s *neonv1alpha1.Safekeeper) { s.Spec.Cluster = validationUpdatedClusterName },
+			))
+			expectInvalidUpdate("Safekeeper storage size immutability", updateSafekeeper(
+				safekeeperKey,
+				func(s *neonv1alpha1.Safekeeper) { s.Spec.StorageConfig.Size = "2Gi" },
+			))
+			expectInvalidUpdate("Safekeeper storage class immutability", updateSafekeeper(
+				safekeeperKey,
+				func(s *neonv1alpha1.Safekeeper) { s.Spec.StorageConfig.StorageClass = ptr.To("slow") },
+			))
 		})
 	})
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -29,6 +29,12 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	neonv1alpha1 "oltp.molnett.org/neon-operator/api/v1alpha1"
 	"oltp.molnett.org/neon-operator/test/fixtures"
 	"oltp.molnett.org/neon-operator/test/utils"
@@ -273,6 +279,164 @@ var _ = Describe("Manager", Ordered, func() {
 		})
 
 		// +kubebuilder:scaffold:e2e-webhooks-checks
+	})
+
+	Context("API validation", func() {
+		It("rejects unsupported values on create", func() {
+			ctx := context.Background()
+			cli := newE2EClient()
+			next := 0
+			name := func(prefix string) string {
+				next++
+				return fmt.Sprintf("validation-%s-%d", prefix, next)
+			}
+			cluster := func(mutate func(*neonv1alpha1.Cluster)) client.Object {
+				obj := fixtures.NewCluster(name("cluster"), namespace)
+				mutate(obj)
+				return obj
+			}
+			project := func(mutate func(*neonv1alpha1.Project)) client.Object {
+				obj := fixtures.NewProject(name("project"), namespace, "cluster-a")
+				mutate(obj)
+				return obj
+			}
+			branch := func(mutate func(*neonv1alpha1.Branch)) client.Object {
+				obj := fixtures.NewBranch(name("branch"), namespace, "project-a")
+				mutate(obj)
+				return obj
+			}
+			pageserver := func(mutate func(*neonv1alpha1.Pageserver)) client.Object {
+				obj := fixtures.NewPageserver(name("pageserver"), namespace, "cluster-a", 0)
+				mutate(obj)
+				return obj
+			}
+			safekeeper := func(mutate func(*neonv1alpha1.Safekeeper)) client.Object {
+				obj := fixtures.NewSafekeeper(name("safekeeper"), namespace, "cluster-a", 0)
+				mutate(obj)
+				return obj
+			}
+
+			for _, tc := range []struct {
+				name string
+				obj  client.Object
+			}{
+				{name: "Cluster numSafekeepers", obj: cluster(func(c *neonv1alpha1.Cluster) { c.Spec.NumSafekeepers = 4 })},
+				{name: "Cluster defaultPGVersion", obj: cluster(func(c *neonv1alpha1.Cluster) { c.Spec.DefaultPGVersion = 13 })},
+				{name: "Cluster neonImage", obj: cluster(func(c *neonv1alpha1.Cluster) { c.Spec.NeonImage = "" })},
+				{name: "Cluster bucketCredentialsSecret.name", obj: cluster(func(c *neonv1alpha1.Cluster) { c.Spec.BucketCredentialsSecret.Name = "" })},
+				{name: "Cluster storageControllerDatabaseSecret.name", obj: cluster(func(c *neonv1alpha1.Cluster) { c.Spec.StorageControllerDatabaseSecret.Name = "" })},
+				{name: "Cluster storageControllerDatabaseSecret.key", obj: cluster(func(c *neonv1alpha1.Cluster) { c.Spec.StorageControllerDatabaseSecret.Key = "" })},
+				{name: "Project cluster", obj: project(func(p *neonv1alpha1.Project) { p.Spec.ClusterName = "" })},
+				{name: "Project tenantId", obj: project(func(p *neonv1alpha1.Project) { p.Spec.TenantID = "not-a-neon-id" })},
+				{name: "Project pgVersion", obj: project(func(p *neonv1alpha1.Project) { p.Spec.PGVersion = 13 })},
+				{name: "Branch projectID", obj: branch(func(b *neonv1alpha1.Branch) { b.Spec.ProjectID = "" })},
+				{name: "Branch timelineID", obj: branch(func(b *neonv1alpha1.Branch) { b.Spec.TimelineID = "not-a-neon-id" })},
+				{name: "Branch pgVersion", obj: branch(func(b *neonv1alpha1.Branch) { b.Spec.PGVersion = 13 })},
+				{name: "Pageserver cluster", obj: pageserver(func(p *neonv1alpha1.Pageserver) { p.Spec.Cluster = "" })},
+				{name: "Pageserver bucketCredentialsSecret.name", obj: pageserver(func(p *neonv1alpha1.Pageserver) { p.Spec.BucketCredentialsSecret.Name = "" })},
+				{name: "Pageserver storageConfig.size", obj: pageserver(func(p *neonv1alpha1.Pageserver) { p.Spec.StorageConfig.Size = "tenGi" })},
+				{name: "Safekeeper cluster", obj: safekeeper(func(s *neonv1alpha1.Safekeeper) { s.Spec.Cluster = "" })},
+				{name: "Safekeeper storageConfig.size", obj: safekeeper(func(s *neonv1alpha1.Safekeeper) { s.Spec.StorageConfig.Size = "tenGi" })},
+			} {
+				By("expecting invalid create for " + tc.name)
+				err := cli.Create(ctx, tc.obj)
+				Expect(apierrors.IsInvalid(err)).To(BeTrue(), "expected invalid error for %s, got %v", tc.name, err)
+			}
+		})
+
+		It("rejects unsafe updates", func() {
+			ctx := context.Background()
+			cli := newE2EClient()
+			expectInvalidUpdate := func(rule string, update func() error) {
+				invalid := false
+				err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					err := update()
+					if apierrors.IsInvalid(err) {
+						invalid = true
+						return nil
+					}
+					return err
+				})
+				Expect(err).NotTo(HaveOccurred(), "expected invalid update for %s, got %v", rule, err)
+				Expect(invalid).To(BeTrue(), "expected invalid update for %s", rule)
+			}
+			updateProject := func(key types.NamespacedName, mutate func(*neonv1alpha1.Project)) func() error {
+				return func() error {
+					obj := &neonv1alpha1.Project{}
+					if err := cli.Get(ctx, key, obj); err != nil {
+						return err
+					}
+					mutate(obj)
+					return cli.Update(ctx, obj)
+				}
+			}
+			updateBranch := func(key types.NamespacedName, mutate func(*neonv1alpha1.Branch)) func() error {
+				return func() error {
+					obj := &neonv1alpha1.Branch{}
+					if err := cli.Get(ctx, key, obj); err != nil {
+						return err
+					}
+					mutate(obj)
+					return cli.Update(ctx, obj)
+				}
+			}
+			updatePageserver := func(key types.NamespacedName, mutate func(*neonv1alpha1.Pageserver)) func() error {
+				return func() error {
+					obj := &neonv1alpha1.Pageserver{}
+					if err := cli.Get(ctx, key, obj); err != nil {
+						return err
+					}
+					mutate(obj)
+					return cli.Update(ctx, obj)
+				}
+			}
+			updateSafekeeper := func(key types.NamespacedName, mutate func(*neonv1alpha1.Safekeeper)) func() error {
+				return func() error {
+					obj := &neonv1alpha1.Safekeeper{}
+					if err := cli.Get(ctx, key, obj); err != nil {
+						return err
+					}
+					mutate(obj)
+					return cli.Update(ctx, obj)
+				}
+			}
+
+			project := fixtures.NewProject("validation-project-update", namespace, "cluster-a")
+			project.Spec.TenantID = "00000000000000000000000000000001"
+			Expect(cli.Create(ctx, project)).To(Succeed())
+
+			projectKey := types.NamespacedName{Name: project.Name, Namespace: namespace}
+			expectInvalidUpdate("Project cluster immutability", updateProject(projectKey, func(p *neonv1alpha1.Project) { p.Spec.ClusterName = "cluster-b" }))
+			expectInvalidUpdate("Project tenantId immutability", updateProject(projectKey, func(p *neonv1alpha1.Project) { p.Spec.TenantID = "00000000000000000000000000000002" }))
+
+			branch := fixtures.NewBranch("validation-branch-update", namespace, "project-a")
+			branch.Spec.TimelineID = "00000000000000000000000000000001"
+			Expect(cli.Create(ctx, branch)).To(Succeed())
+
+			branchKey := types.NamespacedName{Name: branch.Name, Namespace: namespace}
+			expectInvalidUpdate("Branch projectID immutability", updateBranch(branchKey, func(b *neonv1alpha1.Branch) { b.Spec.ProjectID = "project-b" }))
+			expectInvalidUpdate("Branch timelineID immutability", updateBranch(branchKey, func(b *neonv1alpha1.Branch) { b.Spec.TimelineID = "00000000000000000000000000000002" }))
+
+			pageserver := fixtures.NewPageserver("validation-pageserver-update", namespace, "cluster-a", 0)
+			pageserver.Spec.StorageConfig.StorageClass = ptr.To("fast")
+			Expect(cli.Create(ctx, pageserver)).To(Succeed())
+
+			pageserverKey := types.NamespacedName{Name: pageserver.Name, Namespace: namespace}
+			expectInvalidUpdate("Pageserver id immutability", updatePageserver(pageserverKey, func(p *neonv1alpha1.Pageserver) { p.Spec.ID = 1 }))
+			expectInvalidUpdate("Pageserver cluster immutability", updatePageserver(pageserverKey, func(p *neonv1alpha1.Pageserver) { p.Spec.Cluster = "cluster-b" }))
+			expectInvalidUpdate("Pageserver storage size immutability", updatePageserver(pageserverKey, func(p *neonv1alpha1.Pageserver) { p.Spec.StorageConfig.Size = "2Gi" }))
+			expectInvalidUpdate("Pageserver storage class immutability", updatePageserver(pageserverKey, func(p *neonv1alpha1.Pageserver) { p.Spec.StorageConfig.StorageClass = ptr.To("slow") }))
+
+			safekeeper := fixtures.NewSafekeeper("validation-safekeeper-update", namespace, "cluster-a", 0)
+			safekeeper.Spec.StorageConfig.StorageClass = ptr.To("fast")
+			Expect(cli.Create(ctx, safekeeper)).To(Succeed())
+
+			safekeeperKey := types.NamespacedName{Name: safekeeper.Name, Namespace: namespace}
+			expectInvalidUpdate("Safekeeper id immutability", updateSafekeeper(safekeeperKey, func(s *neonv1alpha1.Safekeeper) { s.Spec.ID = 1 }))
+			expectInvalidUpdate("Safekeeper cluster immutability", updateSafekeeper(safekeeperKey, func(s *neonv1alpha1.Safekeeper) { s.Spec.Cluster = "cluster-b" }))
+			expectInvalidUpdate("Safekeeper storage size immutability", updateSafekeeper(safekeeperKey, func(s *neonv1alpha1.Safekeeper) { s.Spec.StorageConfig.Size = "2Gi" }))
+			expectInvalidUpdate("Safekeeper storage class immutability", updateSafekeeper(safekeeperKey, func(s *neonv1alpha1.Safekeeper) { s.Spec.StorageConfig.StorageClass = ptr.To("slow") }))
+		})
 	})
 
 	Context("Neon Lifecycle", func() {


### PR DESCRIPTION
This adds more strict validation of all CRDs using the API server + CEL rather than using webhooks.